### PR TITLE
Added test for quoted fields not throwing an exception (issue #12)

### DIFF
--- a/code/LumenWorks.Framework.IO/Csv/CsvReader.cs
+++ b/code/LumenWorks.Framework.IO/Csv/CsvReader.cs
@@ -1430,6 +1430,12 @@ namespace LumenWorks.Framework.IO.Csv
 								_nextFieldStart++;
 								delimiterSkipped = true;
 							}
+							else if (_nextFieldStart < _bufferLength && (_buffer[_nextFieldStart] == '\r' || _buffer[_nextFieldStart] == '\n'))
+							{
+								_nextFieldStart++;
+								_eol = true;
+								delimiterSkipped = true;
+							}
 							else
 							{
 								delimiterSkipped = false;
@@ -1443,8 +1449,16 @@ namespace LumenWorks.Framework.IO.Csv
 							// If no delimiter is present after the quoted field and it is not the last field, then it is a parsing error
 							if (!delimiterSkipped && !_eof && !(_eol || IsNewLine(_nextFieldStart)))
 								HandleParseError(new MalformedCsvException(GetCurrentRawData(), _nextFieldStart, Math.Max(0, _currentRecordIndex), index), ref _nextFieldStart);
+
 						}
 
+						// If we are at the end, then verify we have all the fields
+						if (_eol || _eof)
+						{
+							if (!initializing && index < _fieldCount - 1)
+								value = HandleMissingField(value, index, ref _nextFieldStart);
+						}
+						
 						if (!discardValue)
 						{
 							if (value == null)

--- a/code/LumenWorks.Framework.Tests.Unit/IO/Csv/CsvReaderMalformedTest.cs
+++ b/code/LumenWorks.Framework.Tests.Unit/IO/Csv/CsvReaderMalformedTest.cs
@@ -180,6 +180,27 @@ namespace LumenWorks.Framework.Tests.Unit.IO.Csv
 
 		[Test()]
 		[ExpectedException(typeof(MissingFieldCsvException))]
+		public void MissingFieldAllQuotedFields_Issue_12()
+		{
+			string sample =
+				"\"A\",\"B\"\n" +
+				"\"1\",\"2\"\n" +
+				"\"3\"\n" +
+				"\"5\",\"6\"";
+
+			string[] buffer = new string[2];
+
+			using (CsvReader csv = new CsvReader(new StringReader(sample), false))
+			{
+				while (csv.ReadNextRecord())
+				{
+					csv.CopyCurrentRecordTo(buffer);
+				}
+			}
+		}
+
+		[Test()]
+		[ExpectedException(typeof(MissingFieldCsvException))]
 		public void MissingFieldQuotedTest1()
 		{
 			const string Data = "a,b,c,d\n1,1,1,1\n2,\"2\"\n3,3,3,3";


### PR DESCRIPTION
When all the fields are quoted, and a field is missing, the **MissingFieldCsvException** is not thrown. This is a small test to demonstrate that behavior as mentioned by @leucospis in issue #12 