### PR TITLE
Fix Debug.Assert() to handle none null case. GetSchemaTableWithoutHeadersTest() now passes unit tests in debug mode

### DIFF
--- a/code/LumenWorks.Framework.IO/Csv/CsvReader.cs
+++ b/code/LumenWorks.Framework.IO/Csv/CsvReader.cs
@@ -828,7 +828,7 @@ namespace LumenWorks.Framework.IO.Csv
 				this.ReadNextRecord(true, false);
 
 			Debug.Assert(Columns != null);
-            Debug.Assert(Columns.Count > 0 || (Columns.Count == 0 && _fieldHeaderIndexes == null));
+			Debug.Assert(Columns.Count > 0 || (Columns.Count == 0 && (_fieldHeaderIndexes == null || _fieldHeaderIndexes.Count == 0)));
 		}
 
 		#endregion


### PR DESCRIPTION
Updated the Debug.Assert() condition as detailed in #14 

I ran the unit tests in AppVeyor, and it looks good.