### PR TITLE
Column.cs => use DateTime.TryParseExact if needed

### DIFF
--- a/code/LumenWorks.Framework.IO/Csv/Column.cs
+++ b/code/LumenWorks.Framework.IO/Csv/Column.cs
@@ -20,6 +20,8 @@ namespace LumenWorks.Framework.IO.Csv
             Type = typeof(string);
             Culture = CultureInfo.CurrentCulture;
             NumberStyles = NumberStyles.Any;
+            DateTimeStyles = DateTimeStyles.None;
+            DateParseExact = null;
         }
 
         /// <summary>
@@ -48,6 +50,10 @@ namespace LumenWorks.Framework.IO.Csv
         public CultureInfo Culture { get; set; }
 
         public NumberStyles NumberStyles { get; set; }
+        
+        public DateTimeStyles DateTimeStyles { get; set; }
+        
+        public string DateParseExact { get; set; }
 
         /// <summary>
         /// Converts the value into the column type.
@@ -162,7 +168,10 @@ namespace LumenWorks.Framework.IO.Csv
                 case "DateTime":
                     {
                         DateTime x;
-                        converted = DateTime.TryParse(value, out x);
+                        if(!string.IsNullOrEmpty(DateParseExact))
+                            converted = DateTime.TryParseExact(value, DateParseExact, Culture, DateTimeStyles, out x);
+                        else
+                            converted = DateTime.TryParse(value, Culture, DateTimeStyles, out x);
                         result = x;
                     }
                     break;


### PR DESCRIPTION
This change allows the use of DateTime.TryParseExact if necessary for the parsed data.
