### PR TITLE
Implement a null removal stream to reduce memory usage and runtime

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 3.9.2 (TBD)
+* Added NullBytesRemoval functionality to reduce memory usage and runtime (@andrewpsy)
+
 #### 3.9.1 (2016-04-09)
 * Added max field length for quoted fields (@criteo)
 * Strengthen Debug.Assert condition in GetSchemaWithoutHeaders (@joshgo)

--- a/code/CsvReaderBenchmarks/CsvReaderBenchmark.cs
+++ b/code/CsvReaderBenchmarks/CsvReaderBenchmark.cs
@@ -10,48 +10,77 @@ using LumenWorks.Framework.IO.Csv;
 
 namespace CsvReaderDemo
 {
-	public sealed class CsvReaderBenchmark
-	{
-		private CsvReaderBenchmark()
-		{
-		}
+    public sealed class CsvReaderBenchmark
+    {
+        private CsvReaderBenchmark()
+        {
+        }
 
-		public static object Run(object[] args)
-		{
-			if (args.Length == 1)
-				Run((string) args[0]);
-			else
-				Run((string) args[0], (int) args[1]);
+        public static object Run(object[] args)
+        {
+            if (args.Length == 1)
+                Run((string) args[0]);
+            else if (args.Length == 2)
+                Run((string) args[0], (int) args[1]);
+            else
+                return RunWithNullRemoval((string) args[0], (int) args[1], (bool) args[2]);
 
-			return null;
-		}
+            return null;
+        }
 
-		public static void Run(string path)
-		{
-			Run(path, -1);
-		}
+        public static void Run(string path)
+        {
+            Run(path, -1);
+        }
 
-		public static void Run(string path, int field)
-		{
-			using (CsvReader csv = new CsvReader(new StreamReader(path), false))
-			{
-				csv.SupportsMultiline = false;
-				string s;
+        private static void Run(string path, int field)
+        {
+            using (CsvReader csv = new CsvReader(new StreamReader(path), false))
+            {
+                csv.SupportsMultiline = false;
+                string s;
 
-				if (field == -1)
-				{
-					while (csv.ReadNextRecord())
-					{
-						for (int i = 0; i < csv.FieldCount; i++)
-							s = csv[i];
-					}
-				}
-				else
-				{
-					while (csv.ReadNextRecord())
-						s = csv[field];
-				}
-			}
-		}
-	}
+                if (field == -1)
+                {
+                    while (csv.ReadNextRecord())
+                    {
+                        for (int i = 0; i < csv.FieldCount; i++)
+                            s = csv[i];
+                    }
+                }
+                else
+                {
+                    while (csv.ReadNextRecord())
+                        s = csv[field];
+                }
+            }
+        }
+
+        private static string RunWithNullRemoval(string path, int field, bool addMark)
+        {
+            using (StreamReader stream = new StreamReader(path))
+            using (CsvReader csv = new CsvReader(stream.BaseStream, false, stream.CurrentEncoding, addMark))
+                //using(CsvReader csv = new CsvReader(File.OpenRead(path),false,Encoding.UTF8,addMark))
+            {
+                csv.SupportsMultiline = false;
+                string cell = string.Empty;
+
+                if (field == -1)
+                {
+                    while (csv.ReadNextRecord())
+                    {
+                        for (int i = 0; i < csv.FieldCount; i++)
+                            cell = csv[i];
+                    }
+                    return string.Format(@"AddMark =({0}) LastCell =({1})", addMark, cell);
+                }
+                else
+                {
+                    while (csv.ReadNextRecord())
+                        cell = csv[field];
+                }
+            }
+            return string.Empty;
+        }
+    }
 }

--- a/code/CsvReaderBenchmarks/Program.cs
+++ b/code/CsvReaderBenchmarks/Program.cs
@@ -1,134 +1,177 @@
 using System;
-using System.Diagnostics;
-
-using LumenWorks.Framework.IO.Csv;
+using System.IO;
 
 namespace CsvReaderDemo
 {
-	class Program
-	{
-		// StopWatch seems to not be accurate enough to be used here (divisions by zero occur when calculating MB/s).
+    class Program
+    {
+        // StopWatch seems to not be accurate enough to be used here (divisions by zero occur when calculating MB/s).
 
-		[System.Runtime.InteropServices.DllImport("Kernel32.dll")]
-		private static extern bool QueryPerformanceCounter(out long lpPerformanceCount);
+        [System.Runtime.InteropServices.DllImport("Kernel32.dll")]
+        private static extern bool QueryPerformanceCounter(out long lpPerformanceCount);
 
-		[System.Runtime.InteropServices.DllImport("Kernel32.dll")]
-		private static extern bool QueryPerformanceFrequency(out long lpFrequency);
+        [System.Runtime.InteropServices.DllImport("Kernel32.dll")]
+        private static extern bool QueryPerformanceFrequency(out long lpFrequency);
 
-		[STAThread()]
-		static void Main(string[] args)
-		{
-			//const string TestFile1 = @"..\..\test1.csv";
-			const string TestFile2 = @"..\..\test2.csv";
-			const string TestFile3 = @"..\..\test3.csv";
+        [STAThread()]
+        static void Main(string[] args)
+        {
+            //const string TestFile1 = @"..\..\test1.csv";
+            const string TestFile2 = @"..\..\test2.csv";
+            const string TestFile3 = @"..\..\test3.csv";
 
-			AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);
+            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);
 
-			if (args.Length > 0)
-			{
-				if (args.Length == 1)
-				{
-					string s = args[0].ToUpper();
+            long fileSize;
+            if (args.Length > 0)
+            {
+                if (args.Length == 1)
+                {
+                    string s = args[0].ToUpper();
 
-					switch (s)
-					{
-						case "CSVREADER":
-							CsvReaderBenchmark.Run(TestFile3);
-							return;
-						case "OLEDB":
-							OleDbBenchmark.Run(TestFile3);
-							return;
-						case "REGEX":
-							RegexBenchmark.Run(TestFile3);
-							return;
-					}
-				}
+                    switch (s)
+                    {
+                        case "CSVREADER":
+                            CsvReaderBenchmark.Run(TestFile3);
+                            return;
+                        case "CSVNULLREMOVALSTREAMREADER":
+                            PerformanceTestWithNullRemovalStreamReader();
+                            return;
+                        case "OLEDB":
+                            OleDbBenchmark.Run(TestFile3);
+                            return;
+                        case "REGEX":
+                            RegexBenchmark.Run(TestFile3);
+                            return;
+                    }
+                }
 
-				Console.WriteLine("Possible values : CsvReader, OleDb, Regex");
-				return;
-			}
+                Console.WriteLine(@"Possible values : CsvReader, CsvNullRemovalStreamReader, OleDb, Regex");
+                return;
+            }
 
-			const int Field = 72;
-			long fileSize = new System.IO.FileInfo(TestFile2).Length / 1024 / 1024;
+            const int Field = 72;
+            fileSize = new System.IO.FileInfo(TestFile2).Length / 1024 / 1024;
 
-			for (int i = 1; i < 4; i++)
-			{
-				object csv;
+            for (int i = 1; i < 4; i++)
+            {
+                object csv;
 
-				Console.WriteLine("Test pass #{0} - All fields\n", i);
+                Console.WriteLine("Test pass #{0} - All fields\n", i);
 
-				DoTest("CsvReader - No cache", fileSize, CsvReaderBenchmark.Run, TestFile2);
-				csv = DoTest("CachedCsvReader - Run 1", fileSize, CachedCsvReaderBenchmark.Run1, TestFile2);
-				DoTest("CachedCsvReader - Run 2", fileSize, CachedCsvReaderBenchmark.Run2, csv);
-				DoTest("TextFieldParser", fileSize, TextFieldParserBenchmark.Run, TestFile2);
-				DoTest("Regex", fileSize, RegexBenchmark.Run, TestFile2);
+                DoTest("CsvReader - No cache", fileSize, CsvReaderBenchmark.Run, TestFile2);
+                csv = DoTest("CachedCsvReader - Run 1", fileSize, CachedCsvReaderBenchmark.Run1, TestFile2);
+                DoTest("CachedCsvReader - Run 2", fileSize, CachedCsvReaderBenchmark.Run2, csv);
+                DoTest("TextFieldParser", fileSize, TextFieldParserBenchmark.Run, TestFile2);
+                DoTest("Regex", fileSize, RegexBenchmark.Run, TestFile2);
 
-				// seems to not be working on Windows 7 with Office 2007 (and I'm not bothering to try to make it run on my machine)
-				//DoTest("OleDb", fileSize, OleDbBenchmark.Run, TestFile2);
+                // seems to not be working on Windows 7 with Office 2007 (and I'm not bothering to try to make it run on my machine)
+                //DoTest("OleDb", fileSize, OleDbBenchmark.Run, TestFile2);
 
-				Console.WriteLine();
+                Console.WriteLine();
 
-				Console.WriteLine("Test pass #{0} - Field #{1} (middle)\n", i, Field);
+                Console.WriteLine("Test pass #{0} - Field #{1} (middle)\n", i, Field);
 
-				DoTest("CsvReader - No cache", fileSize, CsvReaderBenchmark.Run, TestFile2, Field);
-				csv = DoTest("CachedCsvReader - Run 1", fileSize, CachedCsvReaderBenchmark.Run1, TestFile2, Field);
-				DoTest("CachedCsvReader - Run 2", fileSize, CachedCsvReaderBenchmark.Run2, csv, Field);
-				DoTest("TextFieldParser", fileSize, TextFieldParserBenchmark.Run, TestFile2, Field);
-				DoTest("Regex", fileSize, RegexBenchmark.Run, TestFile2, Field);
+                DoTest("CsvReader - No cache", fileSize, CsvReaderBenchmark.Run, TestFile2, Field);
+                csv = DoTest("CachedCsvReader - Run 1", fileSize, CachedCsvReaderBenchmark.Run1, TestFile2, Field);
+                DoTest("CachedCsvReader - Run 2", fileSize, CachedCsvReaderBenchmark.Run2, csv, Field);
+                DoTest("TextFieldParser", fileSize, TextFieldParserBenchmark.Run, TestFile2, Field);
+                DoTest("Regex", fileSize, RegexBenchmark.Run, TestFile2, Field);
 
-				// seems to not be working on Windows 7 with Office 2007 (and I'm not bothering to try to make it run on my machine)
-				//DoTest("OleDb", fileSize, OleDbBenchmark.Run, TestFile2, Field);
+                // seems to not be working on Windows 7 with Office 2007 (and I'm not bothering to try to make it run on my machine)
+                //DoTest("OleDb", fileSize, OleDbBenchmark.Run, TestFile2, Field);
 
-				Console.WriteLine();
-				Console.WriteLine();
-			}
+                Console.WriteLine();
+                Console.WriteLine();
+            }
 
-			Console.WriteLine("Done");
-			Console.ReadLine();
-		}
+            Console.WriteLine("Done");
+            Console.ReadLine();
+        }
 
-		delegate object TestCallback(object[] args);
+        delegate object TestCallback(object[] args);
 
-		static object DoTest(string name, long fileSize, TestCallback testCallback, params object[] args)
-		{
-			long start;
-			long end;
-			long frequency;
-			long clocks;
-			double time;
-			double rate;
+        static object DoTest(string name, long fileSize, TestCallback testCallback, params object[] args)
+        {
+            long start;
+            long end;
+            long frequency;
+            long clocks;
+            double time;
+            double rate;
 
-			QueryPerformanceFrequency(out frequency);
+            QueryPerformanceFrequency(out frequency);
 
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			GC.Collect();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
 
-			QueryPerformanceCounter(out start);
-			object value = testCallback(args);
-			QueryPerformanceCounter(out end);
-			GetStats(start, end, frequency, fileSize, out clocks, out time, out rate);
+            QueryPerformanceCounter(out start);
+            object value = testCallback(args);
+            QueryPerformanceCounter(out end);
+            GetStats(start, end, frequency, fileSize, out clocks, out time, out rate);
 
-			Console.WriteLine("{0} : {1} ticks, {2:f4} sec., {3:f4} MB/sec.", name.PadRight(25), clocks, time, rate);
+            Console.WriteLine("{0} : {1} ticks, {2:f4} sec., {3:f4} MB/sec.", name.PadRight(25), clocks, time, rate);
 
-			return value;
-		}
+            return value;
+        }
 
-		static void GetStats(long start, long end, long frequency, long fileSize, out long clocks, out double time, out double rate)
-		{
-			clocks = end - start;
-			time = (double) clocks / frequency;
-			rate = fileSize / time;
-		}
+        static void GetStats(long start, long end, long frequency, long fileSize, out long clocks, out double time, out double rate)
+        {
+            clocks = end - start;
+            time = (double) clocks / frequency;
+            rate = fileSize / time;
+        }
 
-		static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
-		{
-			if (e.ExceptionObject != null)
-				Console.WriteLine("Unhandled exception :\n\n'{0}'.", e.ExceptionObject.ToString());
-			else
-				Console.WriteLine("Unhandled exception occured.");
+        static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            if (e.ExceptionObject != null)
+                Console.WriteLine("Unhandled exception :\n\n'{0}'.", e.ExceptionObject.ToString());
+            else
+                Console.WriteLine("Unhandled exception occured.");
 
-			Console.ReadLine();
-		}
-	}
+            Console.ReadLine();
+        }
+
+        private static void PerformanceTestWithNullRemovalStreamReader()
+        {
+            string path = string.Empty;
+            try
+            {
+                path = GenerateCsvFile();
+                long fileSize = new FileInfo(path).Length / 1024 / 1024;
+                DoTest("CsvReader -     without using NullRemovalStreamReader", fileSize, CsvReaderBenchmark.Run, path);
+                Console.WriteLine();
+                object result = DoTest("CsvReader - with NullRemovalStreamReader without mark", fileSize, CsvReaderBenchmark.Run, path, -1, false);
+                Console.WriteLine(result + Environment.NewLine);
+                result = DoTest("CsvReader - with NullRemovalStreamReader with    mark", fileSize, CsvReaderBenchmark.Run, path, -1, true);
+                Console.WriteLine(result);
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(path) && File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+
+        private static string GenerateCsvFile()
+        {
+            // generate around 20 million null bytes; file size will be a little over 20MB
+            long numberOfNullBytes = 20 * 1024 * 1024;
+            string path = Path.GetTempFileName();
+
+            using(StreamWriter sw = File.AppendText(path))
+            {
+                for(int i = 1; i <= 5; i++)
+                {
+                    sw.WriteLine("cell{0}1,cell{0}2,cell{0}3", i);
+                }
+                sw.Write("cell61,cell62,cell63 followed by " + numberOfNullBytes + " null bytes");
+                sw.Write(new char[numberOfNullBytes]);
+            }
+            return path;
+        }
+    }
 }

--- a/code/LumenWorks.Framework.IO/Csv/CsvReader.cs
+++ b/code/LumenWorks.Framework.IO/Csv/CsvReader.cs
@@ -32,6 +32,8 @@ using LumenWorks.Framework.IO.Csv.Resources;
 
 namespace LumenWorks.Framework.IO.Csv
 {
+    using System.Text;
+
     /// <summary>
     /// Represents a reader that provides fast, non-cached, forward-only access to CSV data.  
     /// </summary>
@@ -61,6 +63,16 @@ namespace LumenWorks.Framework.IO.Csv
         /// Defines the default comment character indicating that a line is commented out.
         /// </summary>
         public const char DefaultComment = '#';
+
+        /// <summary>
+        /// Defines the default value for AddMark indicating should the CsvReader add null bytes removal mark ([removed x null bytes])
+        /// </summary>
+        private const bool DefaultAddMark = false;
+
+        /// <summary>
+        /// Defines the default value for Threshold indicating when the CsvReader should replace/remove consecutive null bytes
+        /// </summary>
+        private const int DefaultThreshold = 60;
 
         /// <summary>
         /// Contains the <see cref="T:TextReader"/> pointing to the CSV file.
@@ -210,6 +222,25 @@ namespace LumenWorks.Framework.IO.Csv
         private bool _parseErrorFlag;
 
         /// <summary>
+        /// Like CsvReader(TextReader reader, bool hasHeaders) but removes consecutive null bytes above a threshold from source stream.
+        /// </summary>
+        /// <param name="stream">A <see cref="T:Stream"/> pointing to the CSV file.</param>
+        /// <param name="hasHeaders"><see langword="true"/> if field names are located on the first non commented line, otherwise, <see langword="false"/>.</param>
+        /// <param name="encoding"> specifies the encoding of the underlying stream.</param>
+        /// <param name="addMark"><see langword="true"/> if want to add a mark ([removed x null bytes]) to indicate removal, remove silently if <see langword="false"/>.</param>
+        /// <param name="threshold"> only consecutive null bytes above this threshold will be removed or replaced by a mark.</param>
+        /// <exception cref="T:ArgumentNullException">
+        ///     <paramref name="stream"/> is a <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="T:ArgumentException">
+        ///     Cannot read from <paramref name="stream"/>.
+        /// </exception>
+        public CsvReader(Stream stream, bool hasHeaders, Encoding encoding, bool addMark = DefaultAddMark, int threshold = DefaultThreshold)
+            : this(new NullRemovalStreamReader(stream, addMark, threshold, encoding), hasHeaders)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the CsvReader class.
         /// </summary>
         /// <param name="reader">A <see cref="T:TextReader"/> pointing to the CSV file.</param>
@@ -222,6 +253,26 @@ namespace LumenWorks.Framework.IO.Csv
         /// </exception>
         public CsvReader(TextReader reader, bool hasHeaders)
             : this(reader, hasHeaders, DefaultDelimiter, DefaultQuote, DefaultEscape, DefaultComment, ValueTrimmingOptions.UnquotedOnly, DefaultBufferSize)
+        {
+        }
+
+        /// <summary>
+        /// Like CsvReader(TextReader reader, bool hasHeaders, int bufferSize) but removes consecutive null bytes above a threshold from source stream.
+        /// </summary>
+        /// <param name="stream">A <see cref="T:Stream"/> pointing to the CSV file.</param>
+        /// <param name="hasHeaders"><see langword="true"/> if field names are located on the first non commented line, otherwise, <see langword="false"/>.</param>
+        /// <param name="encoding"> specifies the encoding of the underlying stream.</param>
+        /// <param name="bufferSize">The buffer size in bytes.</param>
+        /// <param name="addMark"><see langword="true"/> if want to add a mark ([removed x null bytes]) to indicate removal, remove silently if <see langword="false"/>.</param>
+        /// <param name="threshold"> only consecutive null bytes above this threshold will be removed or replaced by a mark.</param>
+        /// <exception cref="T:ArgumentNullException">
+        ///     <paramref name="stream"/> is a <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="T:ArgumentException">
+        ///     Cannot read from <paramref name="stream"/>.
+        /// </exception>
+        public CsvReader(Stream stream, bool hasHeaders, Encoding encoding, int bufferSize, bool addMark = DefaultAddMark, int threshold = DefaultThreshold)
+            : this(new NullRemovalStreamReader(stream, addMark, threshold, encoding, bufferSize), hasHeaders, bufferSize)
         {
         }
 
@@ -243,6 +294,26 @@ namespace LumenWorks.Framework.IO.Csv
         }
 
         /// <summary>
+        /// Like CsvReader(TextReader reader, bool hasHeaders, char delimiter) but removes consecutive null bytes above a threshold from source stream.
+        /// </summary>
+        /// <param name="stream">A <see cref="T:Stream"/> pointing to the CSV file.</param>
+        /// <param name="hasHeaders"><see langword="true"/> if field names are located on the first non commented line, otherwise, <see langword="false"/>.</param>
+        /// <param name="encoding"> specifies the encoding of the underlying stream.</param>
+        /// <param name="delimiter">The delimiter character separating each field (default is ',').</param>
+        /// <param name="addMark"><see langword="true"/> if want to add a mark ([removed x null bytes]) to indicate removal, remove silently if <see langword="false"/>.</param>
+        /// <param name="threshold"> only consecutive null bytes above this threshold will be removed or replaced by a mark.</param>
+        /// <exception cref="T:ArgumentNullException">
+        ///     <paramref name="stream"/> is a <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="T:ArgumentException">
+        ///     Cannot read from <paramref name="stream"/>.
+        /// </exception>
+        public CsvReader(Stream stream, bool hasHeaders, Encoding encoding, char delimiter, bool addMark = DefaultAddMark, int threshold = DefaultThreshold)
+            : this(new NullRemovalStreamReader(stream, addMark, threshold, encoding), hasHeaders, delimiter)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the CsvReader class.
         /// </summary>
         /// <param name="reader">A <see cref="T:TextReader"/> pointing to the CSV file.</param>
@@ -256,6 +327,27 @@ namespace LumenWorks.Framework.IO.Csv
         /// </exception>
         public CsvReader(TextReader reader, bool hasHeaders, char delimiter)
             : this(reader, hasHeaders, delimiter, DefaultQuote, DefaultEscape, DefaultComment, ValueTrimmingOptions.UnquotedOnly, DefaultBufferSize)
+        {
+        }
+
+        /// <summary>
+        /// Like CsvReader(TextReader reader, bool hasHeaders, char delimiter, int bufferSize) but removes consecutive null bytes above a threshold from source stream.
+        /// </summary>
+        /// <param name="stream">A <see cref="T:Stream"/> pointing to the CSV file.</param>
+        /// <param name="hasHeaders"><see langword="true"/> if field names are located on the first non commented line, otherwise, <see langword="false"/>.</param>
+        /// <param name="encoding"> specifies the encoding of the underlying stream.</param>
+        /// <param name="delimiter">The delimiter character separating each field (default is ',').</param>
+        /// <param name="bufferSize">The buffer size in bytes.</param>
+        /// <param name="addMark"><see langword="true"/> if want to add a mark ([removed x null bytes]) to indicate removal, remove silently if <see langword="false"/>.</param>
+        /// <param name="threshold"> only consecutive null bytes above this threshold will be removed or replaced by a mark.</param>
+        /// <exception cref="T:ArgumentNullException">
+        ///     <paramref name="stream"/> is a <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="T:ArgumentException">
+        ///     Cannot read from <paramref name="stream"/>.
+        /// </exception>
+        public CsvReader(Stream stream, bool hasHeaders, Encoding encoding, char delimiter, int bufferSize, bool addMark = DefaultAddMark, int threshold = DefaultThreshold)
+            : this(new NullRemovalStreamReader(stream, addMark, threshold, encoding, bufferSize), hasHeaders, delimiter, bufferSize)
         {
         }
 
@@ -274,6 +366,35 @@ namespace LumenWorks.Framework.IO.Csv
         /// </exception>
         public CsvReader(TextReader reader, bool hasHeaders, char delimiter, int bufferSize)
             : this(reader, hasHeaders, delimiter, DefaultQuote, DefaultEscape, DefaultComment, ValueTrimmingOptions.UnquotedOnly, bufferSize)
+        {
+        }
+
+        /// <summary>
+        ///     Like CsvReader(TextReader reader, bool hasHeaders, char delimiter, char quote, char escape, char comment, ValueTrimmingOptions trimmingOptions, string nullValue)
+        ///     but removes consecutive null bytes above a threshold from source stream.
+        /// </summary>
+        /// <param name="stream">A <see cref="T:Stream"/> pointing to the CSV file.</param>
+        /// <param name="hasHeaders"><see langword="true"/> if field names are located on the first non commented line, otherwise, <see langword="false"/>.</param>
+        /// <param name="encoding"> specifies the encoding of the underlying stream.</param>
+        /// <param name="delimiter">The delimiter character separating each field (default is ',').</param>
+        /// <param name="quote">The quotation character wrapping every field (default is ''').</param>
+        /// <param name="escape">
+        /// The escape character letting insert quotation characters inside a quoted field (default is '\').
+        /// If no escape character, set to '\0' to gain some performance.
+        /// </param>
+        /// <param name="comment">The comment character indicating that a line is commented out (default is '#').</param>
+        /// <param name="trimmingOptions">Determines which values should be trimmed.</param>
+        /// <param name="nullValue">The value which denotes a DbNull-value.</param>
+        /// <param name="addMark"><see langword="true"/> if want to add a mark ([removed x null bytes]) to indicate removal, remove silently if <see langword="false"/>.</param>
+        /// <param name="threshold"> only consecutive null bytes above this threshold will be removed or replaced by a mark.</param>
+        /// <exception cref="T:ArgumentNullException">
+        ///     <paramref name="stream"/> is a <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="T:ArgumentException">
+        ///     Cannot read from <paramref name="stream"/>.
+        /// </exception>
+        public CsvReader(Stream stream, bool hasHeaders, Encoding encoding, char delimiter, char quote, char escape, char comment, ValueTrimmingOptions trimmingOptions, string nullValue = null, bool addMark = DefaultAddMark, int threshold = DefaultThreshold)
+            : this(new NullRemovalStreamReader(stream, addMark, threshold, encoding), hasHeaders, delimiter, quote, escape, comment, trimmingOptions, nullValue)
         {
         }
 
@@ -299,6 +420,36 @@ namespace LumenWorks.Framework.IO.Csv
         /// </exception>
         public CsvReader(TextReader reader, bool hasHeaders, char delimiter, char quote, char escape, char comment, ValueTrimmingOptions trimmingOptions, string nullValue = null)
             : this(reader, hasHeaders, delimiter, quote, escape, comment, trimmingOptions, DefaultBufferSize, nullValue)
+        {
+        }
+
+        /// <summary>
+        ///     Like CsvReader(TextReader reader, bool hasHeaders, char delimiter, char quote, char escape, char comment, ValueTrimmingOptions trimmingOptions, int bufferSize, string nullValue)
+        ///     but removes consecutive null bytes above a threshold from source stream.
+        /// </summary>
+        /// <param name="stream">A <see cref="T:Stream"/> pointing to the CSV file.</param>
+        /// <param name="hasHeaders"><see langword="true"/> if field names are located on the first non commented line, otherwise, <see langword="false"/>.</param>
+        /// <param name="encoding"> specifies the encoding of the underlying stream.</param>
+        /// <param name="delimiter">The delimiter character separating each field (default is ',').</param>
+        /// <param name="quote">The quotation character wrapping every field (default is ''').</param>
+        /// <param name="escape">
+        /// The escape character letting insert quotation characters inside a quoted field (default is '\').
+        /// If no escape character, set to '\0' to gain some performance.
+        /// </param>
+        /// <param name="comment">The comment character indicating that a line is commented out (default is '#').</param>
+        /// <param name="trimmingOptions">Determines which values should be trimmed.</param>
+        /// <param name="bufferSize">The buffer size in bytes.</param>
+        /// <param name="nullValue">The value which denotes a DbNull-value.</param>
+        /// <param name="addMark"><see langword="true"/> if want to add a mark ([removed x null bytes]) to indicate removal, remove silently if <see langword="false"/>.</param>
+        /// <param name="threshold"> only consecutive null bytes above this threshold will be removed or replace by a mark.</param>
+        /// <exception cref="T:ArgumentNullException">
+        ///     <paramref name="stream"/> is a <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="T:ArgumentException">
+        ///     Cannot read from <paramref name="stream"/>.
+        /// </exception>
+        public CsvReader(Stream stream, bool hasHeaders, Encoding encoding, char delimiter, char quote, char escape, char comment, ValueTrimmingOptions trimmingOptions, int bufferSize, string nullValue = null, bool addMark = DefaultAddMark, int threshold = DefaultThreshold)
+            : this(new NullRemovalStreamReader(stream, addMark, threshold, encoding, bufferSize), hasHeaders, delimiter, quote, escape, comment, trimmingOptions, bufferSize, nullValue)
         {
         }
 

--- a/code/LumenWorks.Framework.IO/Csv/Stream/NullRemovalStream.cs
+++ b/code/LumenWorks.Framework.IO/Csv/Stream/NullRemovalStream.cs
@@ -1,0 +1,188 @@
+﻿namespace LumenWorks.Framework.IO
+{
+    using System;
+    using System.IO;
+
+    using Csv.Resources;
+
+    public class NullRemovalStream : Stream
+    {
+        private bool _addMark;
+        private byte[] _buffer;
+        private int _bufferIndex;
+        private int _bufferSize;
+        private Stream _source;
+        private int _threshold;
+
+        /// <summary>
+        ///     A stream implmentation that removes consecutive null bytes above a threshold from source
+        /// </summary>
+        /// <param name="source"> A <see cref="T:Stream" /> pointing to the source data</param>
+        /// <param name="addMark">
+        ///     add a mark ([removed x null bytes]) to indicate removal if set to <see langword="true" />, remove silently if
+        ///     <see langword="false" />
+        /// </param>
+        /// <param name="threshold"> only consecutive null bytes above this threshold will be removed or replaced by a mark</param>
+        public NullRemovalStream(Stream source, bool addMark = true, int threshold = 60, int bufferSize = 4096)
+        {
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), bufferSize, ExceptionMessage.BufferSizeTooSmall);
+            }
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+
+            _addMark = addMark;
+            _buffer = new byte [bufferSize];
+            _threshold = threshold < 60 ? 60 : threshold;
+            PopulateBuffer();
+        }
+
+        public override bool CanRead
+        {
+            get { return _source.CanRead; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return _source.CanSeek; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return _source.CanWrite; }
+        }
+
+        public override long Length
+        {
+            get { return _source.Length; }
+        }
+
+        public override long Position
+        {
+            get { return _source.Position; }
+            set { _source.Position = value; }
+        }
+
+        public override void Close()
+        {
+            _source.Close();
+        }
+
+        public override void Flush()
+        {
+            _source.Flush();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _source.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            _source.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _source.Write(buffer, offset, count);
+        }
+
+        public override int Read(byte[] target, int offset, int count)
+        {
+            if (count > target.Length - offset)
+            {
+                return 0;
+            }
+
+            int targetIndex = offset;
+            int dataRead = 0;
+            int nullCount = 0;
+
+            if (_bufferSize == 0)
+            {
+                return 0;
+            }
+
+            byte lastByteInBuffer = 1;
+            while (dataRead < count)
+            {
+                // if last PopulateBuffer() exhausted the source stream, _bufferSize will be less than 4096
+                lastByteInBuffer = 1;
+                if (_bufferIndex == _bufferSize)
+                {
+                    // save the current last byte in _buffer before populating _buffer again
+                    lastByteInBuffer = _bufferIndex > 0 ? _buffer[_bufferIndex - 1] : lastByteInBuffer;
+                    PopulateBuffer();
+                    if (_bufferSize == 0)
+                    {
+                        break;
+                    }
+                }
+
+                byte current = _buffer[_bufferIndex];
+                if (current == 0)
+                {
+                    nullCount++;
+                }
+                else
+                {
+                    bool lastIsNull = _bufferIndex > 0 ? _buffer[_bufferIndex - 1] == 0 : lastByteInBuffer == 0;
+                    int newTargetIndex = targetIndex;
+                    if (lastIsNull)
+                    {
+                        // first non null byte
+                        newTargetIndex = Process(target, targetIndex, nullCount);
+                        nullCount = 0;
+                    }
+                    target[newTargetIndex] = current;
+                    dataRead += newTargetIndex - targetIndex + 1;
+                    targetIndex = newTargetIndex + 1;
+                }
+                _bufferIndex++;
+            }
+            if (nullCount > 0 && dataRead == 0 || _bufferSize == 0 && lastByteInBuffer == 0)
+            {
+                // the end of the source stream is a null byte so couldn't enter the else block in the while loop above, do the needful
+                return Process(target, targetIndex, nullCount);
+            }
+            return dataRead;
+        }
+
+        private int Process(byte[] target, int targetIndex, int nullCount)
+        {
+            if (nullCount < _threshold)
+            {
+                // add null bytes back to target if (addMark == true but nullCount < _threshold)
+                while (nullCount > 0)
+                {
+                    target[targetIndex] = 0;
+                    targetIndex++;
+                    nullCount--;
+                }
+                return targetIndex;
+            }
+
+            if (!_addMark)
+            {
+                return targetIndex;
+            }
+
+            // nullCount >= _threshold
+            string template = "[removed {0} null bytes]";
+            string mark = string.Format(template, nullCount);
+            foreach (char c in mark)
+            {
+                target[targetIndex] = Convert.ToByte(c);
+                targetIndex++;
+            }
+            return targetIndex;
+        }
+
+        private void PopulateBuffer()
+        {
+            _bufferSize = _source.Read(_buffer, 0, _buffer.Length);
+            _bufferIndex = 0;
+        }
+    }
+}

--- a/code/LumenWorks.Framework.IO/Csv/Stream/NullRemovalStreamReader.cs
+++ b/code/LumenWorks.Framework.IO/Csv/Stream/NullRemovalStreamReader.cs
@@ -1,0 +1,13 @@
+﻿namespace LumenWorks.Framework.IO
+{
+    using System.IO;
+    using System.Text;
+
+    public class NullRemovalStreamReader : StreamReader
+    {
+        public NullRemovalStreamReader(Stream stream, bool addMark, int threshold, Encoding encoding, int bufferSize = 4096, bool detectEncoding = false)
+            : base(new NullRemovalStream(stream, addMark, threshold, bufferSize), encoding, detectEncoding, bufferSize)
+        {
+        }
+    }
+}

--- a/code/LumenWorks.Framework.IO/LumenWorks.Framework.IO.csproj
+++ b/code/LumenWorks.Framework.IO/LumenWorks.Framework.IO.csproj
@@ -82,6 +82,8 @@
     <Compile Include="Csv\Exceptions\MalformedCsvException.cs" />
     <Compile Include="Csv\Exceptions\MissingFieldCsvException.cs" />
     <Compile Include="Csv\MissingFieldAction.cs" />
+    <Compile Include="Csv\Stream\NullRemovalStream.cs" />
+    <Compile Include="Csv\Stream\NullRemovalStreamReader.cs" />
     <Compile Include="Csv\ParseErrorAction.cs" />
     <Compile Include="Csv\Resources\ExceptionMessage.Designer.cs" />
     <Compile Include="Csv\Column.cs" />

--- a/code/LumenWorks.Framework.Tests.Unit/IO/Csv/CsvReaderWithNullRemovalTest.cs
+++ b/code/LumenWorks.Framework.Tests.Unit/IO/Csv/CsvReaderWithNullRemovalTest.cs
@@ -1,0 +1,1477 @@
+// LumenWorks.Framework.Tests.Unit.IO.CSV.CsvReaderWithNullRmovalTest
+// Copyright (c) 2005 Sébastien Lorion
+//
+// MIT license (http://en.wikipedia.org/wiki/MIT_License)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights 
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do so, 
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE 
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+// A special thanks goes to "shriop" at CodeProject for providing many of the standard and Unicode parsing tests.
+
+namespace LumenWorks.Framework.Tests.Unit.IO.Csv
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Windows.Forms;
+
+    using NUnit.Framework;
+
+    using Framework.IO.Csv;
+
+    [TestFixture()]
+    public class CsvReaderWithNullRemovalTest
+    {
+        #region Argument validation tests
+
+        #region Constructors
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ArgumentTestCtor1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(null, false, Encoding.ASCII))
+            {
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ArgumentTestCtor2WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("hello world!")), false, Encoding.ASCII, 0))
+            {
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ArgumentTestCtor3WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("hello world!")), false, Encoding.ASCII, -1))
+            {
+            }
+        }
+
+        [Test]
+        public void ArgumentTestCtor4WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("hello world!")), false, Encoding.ASCII, 123))
+            {
+                Assert.AreEqual("hello world!".Length, csv.BufferSize);
+            }
+        }
+
+        #endregion
+
+        #region Indexers
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ArgumentTestIndexer1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                string s = csv[-1];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ArgumentTestIndexer2WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                string s = csv[CsvReaderSampleData.SampleData1RecordCount];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void ArgumentTestIndexer3WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                string s = csv["asdf"];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void ArgumentTestIndexer4WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                string s = csv[CsvReaderSampleData.SampleData1Header0];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ArgumentTestIndexer5WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                string s = csv[null];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ArgumentTestIndexer6WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                string s = csv[string.Empty];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ArgumentTestIndexer7WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                string s = csv[null];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ArgumentTestIndexer8WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                string s = csv[string.Empty];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ArgumentTestIndexer9WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                string s = csv["asdf"];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ArgumentTestIndexer10WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                string s = csv[-1, 0];
+            }
+        }
+
+        #endregion
+
+        #region CopyCurrentRecordTo
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ArgumentTestCopyCurrentRecordTo1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                csv.CopyCurrentRecordTo(null);
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ArgumentTestCopyCurrentRecordTo2WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                csv.CopyCurrentRecordTo(new string[1], -1);
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ArgumentTestCopyCurrentRecordTo3WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                csv.CopyCurrentRecordTo(new string[1], 1);
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ArgumentTestCopyCurrentRecordTo4WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                csv.ReadNextRecord();
+                csv.CopyCurrentRecordTo(new string[CsvReaderSampleData.SampleData1RecordCount - 1], 0);
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ArgumentTestCopyCurrentRecordTo5WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                csv.ReadNextRecord();
+                csv.CopyCurrentRecordTo(new string[CsvReaderSampleData.SampleData1RecordCount], 1);
+            }
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Parsing tests
+
+        [Test]
+        public void ParsingTest1WithNullRemovalStreamReader()
+        {
+            const string data = "1\r\n\r\n1";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest2WithNullRemovalStreamReader()
+        {
+            // ["Bob said, ""Hey!""",2, 3 ]
+            const string data = "\"Bob said, \"\"Hey!\"\"\",2, 3 ";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(@"Bob said, ""Hey!""", csv[0]);
+                Assert.AreEqual("2", csv[1]);
+                Assert.AreEqual("3", csv[2]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '"', '"', '#', ValueTrimmingOptions.None))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(@"Bob said, ""Hey!""", csv[0]);
+                Assert.AreEqual("2", csv[1]);
+                Assert.AreEqual(" 3 ", csv[2]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest3WithNullRemovalStreamReader()
+        {
+            const string data = "1\r2\n";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("2", csv[0]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest4WithNullRemovalStreamReader()
+        {
+            const string data = "\"\n\r\n\n\r\r\",,\t,\n";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+
+                Assert.AreEqual(4, csv.FieldCount);
+
+                Assert.AreEqual("\n\r\n\n\r\r", csv[0]);
+                Assert.AreEqual("", csv[1]);
+                Assert.AreEqual("", csv[2]);
+                Assert.AreEqual("", csv[3]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest5WithNullRemovalStreamReader()
+        {
+            Checkdata5(1024);
+
+            // some tricky ones ...
+
+            Checkdata5(1);
+            Checkdata5(9);
+            Checkdata5(14);
+            Checkdata5(39);
+            Checkdata5(166);
+            Checkdata5(194);
+        }
+
+        [Test]
+        public void ParsingTest5_RandomBufferSizesWithNullRemovalStreamReader()
+        {
+            Random random = new Random();
+
+            for (int i = 0; i < 1000; i++)
+                Checkdata5(random.Next(1, 512));
+        }
+
+        private void Checkdata5(int bufferSize)
+        {
+            const string data = CsvReaderSampleData.SampleData1;
+
+            try
+            {
+                using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), true, Encoding.ASCII, bufferSize))
+                {
+                    CsvReaderSampleData.CheckSampleData1(csv, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(string.Format("BufferSize={0}", bufferSize), ex);
+            }
+        }
+
+        [Test]
+        public void ParsingTest6WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("1,2")), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual("2", csv[1]);
+                Assert.AreEqual(',', csv.Delimiter);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(2, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest7WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("\r\n1\r\n")), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(',', csv.Delimiter);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.AreEqual("1", csv[0]);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest8WithNullRemovalStreamReader()
+        {
+            const string data = "\"bob said, \"\"Hey!\"\"\",2, 3 ";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\"', '\"', '#', ValueTrimmingOptions.UnquotedOnly))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("bob said, \"Hey!\"", csv[0]);
+                Assert.AreEqual("2", csv[1]);
+                Assert.AreEqual("3", csv[2]);
+                Assert.AreEqual(',', csv.Delimiter);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(3, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest9WithNullRemovalStreamReader()
+        {
+            const string data = ",";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(string.Empty, csv[0]);
+                Assert.AreEqual(string.Empty, csv[1]);
+                Assert.AreEqual(',', csv.Delimiter);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(2, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest10WithNullRemovalStreamReader()
+        {
+            const string data = "1\r2";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("2", csv[0]);
+                Assert.AreEqual(1, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest11WithNullRemovalStreamReader()
+        {
+            const string data = "1\n2";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("2", csv[0]);
+                Assert.AreEqual(1, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest12WithNullRemovalStreamReader()
+        {
+            const string data = "1\r\n2";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("2", csv[0]);
+                Assert.AreEqual(1, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest13WithNullRemovalStreamReader()
+        {
+            const string data = "1\r";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest14WithNullRemovalStreamReader()
+        {
+            const string data = "1\n";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest15WithNullRemovalStreamReader()
+        {
+            const string data = "1\r\n";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest16WithNullRemovalStreamReader()
+        {
+            const string data = "1\r2\n";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, '\r', '"', '\"', '#', ValueTrimmingOptions.UnquotedOnly))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual("2", csv[1]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(2, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest17WithNullRemovalStreamReader()
+        {
+            const string data = "\"July 4th, 2005\"";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("July 4th, 2005", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest18WithNullRemovalStreamReader()
+        {
+            const string data = " 1";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\"', '\"', '#', ValueTrimmingOptions.None))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(" 1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest19WithNullRemovalStreamReader()
+        {
+            string data = string.Empty;
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest20WithNullRemovalStreamReader()
+        {
+            const string data = "user_id,name\r\n1,Bruce";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), true, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual("Bruce", csv[1]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(2, csv.FieldCount);
+                Assert.AreEqual("1", csv["user_id"]);
+                Assert.AreEqual("Bruce", csv["name"]);
+                Assert.IsFalse(csv.ReadNextRecord());
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest21WithNullRemovalStreamReader()
+        {
+            const string data = "\"data \r\n here\"";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\"', '\"', '#', ValueTrimmingOptions.None))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("data \r\n here", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest22WithNullRemovalStreamReader()
+        {
+            const string data = "\r\r\n1\r";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, '\r', '\"', '\"', '#', ValueTrimmingOptions.None))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(3, csv.FieldCount);
+
+                Assert.AreEqual(string.Empty, csv[0]);
+                Assert.AreEqual(string.Empty, csv[1]);
+                Assert.AreEqual(string.Empty, csv[2]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(string.Empty, csv[1]);
+                Assert.AreEqual(1, csv.CurrentRecordIndex);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest23WithNullRemovalStreamReader()
+        {
+            const string data = "\"double\"\"\"\"double quotes\"";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\"', '\"', '#', ValueTrimmingOptions.None))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("double\"\"double quotes", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest24WithNullRemovalStreamReader()
+        {
+            const string data = "1\r";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest25WithNullRemovalStreamReader()
+        {
+            const string data = "1\r\n";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest26WithNullRemovalStreamReader()
+        {
+            const string data = "1\n";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest27WithNullRemovalStreamReader()
+        {
+            const string data = "'bob said, ''Hey!''',2, 3 ";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\'', '\'', '#', ValueTrimmingOptions.UnquotedOnly))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("bob said, 'Hey!'", csv[0]);
+                Assert.AreEqual("2", csv[1]);
+                Assert.AreEqual("3", csv[2]);
+                Assert.AreEqual(',', csv.Delimiter);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(3, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest28WithNullRemovalStreamReader()
+        {
+            const string data = "\"data \"\" here\"";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\0', '\\', '#', ValueTrimmingOptions.None))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("\"data \"\" here\"", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest29WithNullRemovalStreamReader()
+        {
+            string data = new string('a', 75) + "," + new string('b', 75);
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(new string('a', 75), csv[0]);
+                Assert.AreEqual(new string('b', 75), csv[1]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(2, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest30WithNullRemovalStreamReader()
+        {
+            const string data = "1\r\n\r\n1";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(1, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest31WithNullRemovalStreamReader()
+        {
+            const string data = "1\r\n# bunch of crazy stuff here\r\n1";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\"', '\"', '#', ValueTrimmingOptions.None))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual(1, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest32WithNullRemovalStreamReader()
+        {
+            const string data = "\"1\",Bruce\r\n\"2\n\",Toni\r\n\"3\",Brian\r\n";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\"', '\"', '#', ValueTrimmingOptions.None))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("1", csv[0]);
+                Assert.AreEqual("Bruce", csv[1]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(2, csv.FieldCount);
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("2\n", csv[0]);
+                Assert.AreEqual("Toni", csv[1]);
+                Assert.AreEqual(1, csv.CurrentRecordIndex);
+                Assert.AreEqual(2, csv.FieldCount);
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("3", csv[0]);
+                Assert.AreEqual("Brian", csv[1]);
+                Assert.AreEqual(2, csv.CurrentRecordIndex);
+                Assert.AreEqual(2, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest33WithNullRemovalStreamReader()
+        {
+            const string data = "\"double\\\\\\\\double backslash\"";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\"', '\\', '#', ValueTrimmingOptions.None))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("double\\\\double backslash", csv[0]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest34WithNullRemovalStreamReader()
+        {
+            const string data = "\"Chicane\", \"Love on the Run\", \"Knight Rider\", \"This field contains a comma, but it doesn't matter as the field is quoted\"\r\n" +
+                      "\"Samuel Barber\", \"Adagio for Strings\", \"Classical\", \"This field contains a double quote character, \"\", but it doesn't matter as it is escaped\"";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, ',', '\"', '\"', '#', ValueTrimmingOptions.UnquotedOnly))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("Chicane", csv[0]);
+                Assert.AreEqual("Love on the Run", csv[1]);
+                Assert.AreEqual("Knight Rider", csv[2]);
+                Assert.AreEqual("This field contains a comma, but it doesn't matter as the field is quoted", csv[3]);
+                Assert.AreEqual(0, csv.CurrentRecordIndex);
+                Assert.AreEqual(4, csv.FieldCount);
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("Samuel Barber", csv[0]);
+                Assert.AreEqual("Adagio for Strings", csv[1]);
+                Assert.AreEqual("Classical", csv[2]);
+                Assert.AreEqual("This field contains a double quote character, \", but it doesn't matter as it is escaped", csv[3]);
+                Assert.AreEqual(1, csv.CurrentRecordIndex);
+                Assert.AreEqual(4, csv.FieldCount);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest35WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("\t")), false, Encoding.ASCII, '\t'))
+            {
+                Assert.AreEqual(2, csv.FieldCount);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+
+                Assert.AreEqual(string.Empty, csv[0]);
+                Assert.AreEqual(string.Empty, csv[1]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest36WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                csv.SupportsMultiline = false;
+                CsvReaderSampleData.CheckSampleData1(csv, true);
+            }
+        }
+
+        [Test]
+        public void ParsingTest37WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                csv.SupportsMultiline = false;
+                CsvReaderSampleData.CheckSampleData1(csv, true);
+            }
+        }
+
+        [Test]
+        public void ParsingTest38WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("abc,def,ghi\n")), false, Encoding.ASCII))
+            {
+                int fieldCount = csv.FieldCount;
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("abc", csv[0]);
+                Assert.AreEqual("def", csv[1]);
+                Assert.AreEqual("ghi", csv[2]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest39WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("00,01,   \n10,11,   ")), false, Encoding.ASCII, CsvReader.DefaultDelimiter, CsvReader.DefaultQuote, CsvReader.DefaultEscape, CsvReader.DefaultComment, ValueTrimmingOptions.UnquotedOnly, 1))
+            {
+                int fieldCount = csv.FieldCount;
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("00", csv[0]);
+                Assert.AreEqual("01", csv[1]);
+                Assert.AreEqual("", csv[2]);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("10", csv[0]);
+                Assert.AreEqual("11", csv[1]);
+                Assert.AreEqual("", csv[2]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest40WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("\"00\",\n\"10\",")), false, Encoding.ASCII))
+            {
+                Assert.AreEqual(2, csv.FieldCount);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("00", csv[0]);
+                Assert.AreEqual(string.Empty, csv[1]);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("10", csv[0]);
+                Assert.AreEqual(string.Empty, csv[1]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest41WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("First record          ,Second record")), false, Encoding.ASCII, CsvReader.DefaultDelimiter, CsvReader.DefaultQuote, CsvReader.DefaultEscape, CsvReader.DefaultComment, ValueTrimmingOptions.UnquotedOnly, 16))
+            {
+                Assert.AreEqual(2, csv.FieldCount);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("First record", csv[0]);
+                Assert.AreEqual("Second record", csv[1]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest42WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(" ")), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(1, csv.FieldCount);
+                Assert.AreEqual(string.Empty, csv[0]);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void ParsingTest43WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("a,b\n   ")), false, Encoding.ASCII))
+            {
+                csv.SkipEmptyLines = true;
+                csv.MissingFieldAction = MissingFieldAction.ReplaceByNull;
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(2, csv.FieldCount);
+                Assert.AreEqual("a", csv[0]);
+                Assert.AreEqual("b", csv[1]);
+
+                csv.ReadNextRecord();
+                Assert.AreEqual(string.Empty, csv[0]);
+                Assert.AreEqual(null, csv[1]);
+            }
+        }
+
+        [ExpectedException(typeof(MalformedCsvException))]
+        [Test]
+        public void ParsingTest44WithNullRemovalStreamReader()
+        {
+            const string data = "\"01234567891\"\r\ntest";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                csv.MaxQuotedFieldLength = 10;
+                csv.ReadNextRecord();
+            }
+        }
+
+        [Test]
+        public void ParsingTest45WithNullRemovalStreamReader()
+        {
+            const string data = "\"01234567891\"\r\ntest";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII))
+            {
+                csv.MaxQuotedFieldLength = 11;
+                csv.ReadNextRecord();
+                Assert.AreEqual("01234567891", csv[0]);
+            }
+        }
+
+        #endregion
+
+        #region UnicodeParsing tests
+
+        [Test]
+        public void UnicodeParsingTest1WithNullRemovalStreamReader()
+        {
+            // control characters and comma are skipped
+
+            char[] raw = new char[65536 - 13];
+
+            for (int i = 0; i < raw.Length; i++)
+                raw[i] = (char)(i + 14);
+
+            raw[44 - 14] = ' '; // skip comma
+
+            string data = new string(raw);
+
+            byte[] dataBytes = Encoding.Unicode.GetBytes(data);
+            string dataBack = Encoding.Unicode.GetString(dataBytes);
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(dataBytes), false, Encoding.Unicode))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(dataBack, csv[0]);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void UnicodeParsingTest2WithNullRemovalStreamReader()
+        {
+            byte[] buffer;
+
+            string test = "München";
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (TextWriter writer = new StreamWriter(stream, Encoding.UTF8))
+                {
+                    writer.WriteLine(test);
+                }
+
+                buffer = stream.ToArray();
+            }
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(buffer), false, Encoding.UTF8))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(test, csv[0]);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void UnicodeParsingTest3WithNullRemovalStreamReader()
+        {
+            byte[] buffer;
+
+            string test = "München";
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (TextWriter writer = new StreamWriter(stream, Encoding.UTF32))
+                {
+                    writer.Write(test);
+                }
+
+                buffer = stream.ToArray();
+            }
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(buffer), false, Encoding.UTF32))
+            {
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(test, csv[0]);
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        #endregion
+
+        #region FieldCount
+
+        [Test]
+        public void FieldCountTest1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                CsvReaderSampleData.CheckSampleData1(csv, true);
+            }
+        }
+
+        #endregion
+
+        #region GetFieldHeaders
+
+        [Test]
+        public void GetFieldHeadersTest1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                string[] headers = csv.GetFieldHeaders();
+
+                Assert.IsNotNull(headers);
+                Assert.AreEqual(0, headers.Length);
+            }
+        }
+
+        [Test]
+        public void GetFieldHeadersTest2WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                string[] headers = csv.GetFieldHeaders();
+
+                Assert.IsNotNull(headers);
+                Assert.AreEqual(CsvReaderSampleData.SampleData1RecordCount, headers.Length);
+
+                Assert.AreEqual(CsvReaderSampleData.SampleData1Header0, headers[0]);
+                Assert.AreEqual(CsvReaderSampleData.SampleData1Header1, headers[1]);
+                Assert.AreEqual(CsvReaderSampleData.SampleData1Header2, headers[2]);
+                Assert.AreEqual(CsvReaderSampleData.SampleData1Header3, headers[3]);
+                Assert.AreEqual(CsvReaderSampleData.SampleData1Header4, headers[4]);
+                Assert.AreEqual(CsvReaderSampleData.SampleData1Header5, headers[5]);
+
+                Assert.AreEqual(0, csv.GetFieldIndex(CsvReaderSampleData.SampleData1Header0));
+                Assert.AreEqual(1, csv.GetFieldIndex(CsvReaderSampleData.SampleData1Header1));
+                Assert.AreEqual(2, csv.GetFieldIndex(CsvReaderSampleData.SampleData1Header2));
+                Assert.AreEqual(3, csv.GetFieldIndex(CsvReaderSampleData.SampleData1Header3));
+                Assert.AreEqual(4, csv.GetFieldIndex(CsvReaderSampleData.SampleData1Header4));
+                Assert.AreEqual(5, csv.GetFieldIndex(CsvReaderSampleData.SampleData1Header5));
+            }
+        }
+
+        [Test]
+        public void GetFieldHeadersTest_EmptyCsvWithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("#asdf\n\n#asdf,asdf")), true, Encoding.ASCII))
+            {
+                string[] headers = csv.GetFieldHeaders();
+
+                Assert.IsNotNull(headers);
+                Assert.AreEqual(0, headers.Length);
+            }
+        }
+
+        [TestCase((string)null)]
+        [TestCase("")]
+        [TestCase("AnotherName")]
+        public void GetFieldHeaders_WithEmptyHeaderNamesWithNullRemovalStreamReader(string defaultHeaderName)
+        {
+            if (defaultHeaderName == null)
+                defaultHeaderName = "Column";
+
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(",  ,,aaa,\"   \",,,")), true, Encoding.ASCII))
+            {
+                csv.DefaultHeaderName = defaultHeaderName;
+
+                Assert.IsFalse(csv.ReadNextRecord());
+                Assert.AreEqual(8, csv.FieldCount);
+
+                string[] headers = csv.GetFieldHeaders();
+                Assert.AreEqual(csv.FieldCount, headers.Length);
+
+                Assert.AreEqual("aaa", headers[3]);
+                foreach (int index in new[] { 0, 1, 2, 4, 5, 6, 7 })
+                    Assert.AreEqual(defaultHeaderName + index, headers[index]);
+            }
+        }
+
+        #endregion
+
+        [Test]
+        public void CachedNoHeaderWithNullRemovalStreamReader()
+        {
+            CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("12345678;Hello\r\n78945612;World")), false, Encoding.ASCII, ';');
+            DataGridView dgv = new DataGridView { DataSource = csv };
+            dgv.Refresh();
+        }
+
+        #region HasHeader
+
+        [Test]
+        public void HasHeader_NullHeaderWithNullRemovalStreamReader()
+        {
+            using(CsvReader csvReader = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("Header1,Header2\r\nValue1,Value2")), true, Encoding.ASCII))
+            {
+                Assert.Throws<ArgumentNullException>(delegate
+                {
+                    csvReader.HasHeader(null);
+                });
+            }
+        }
+
+        [Test]
+        public void HasHeader_HeaderExistsWithNullRemovalStreamReader()
+        {
+            string header = "First Name";
+
+            using (CsvReader csvReader = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                Assert.IsTrue(csvReader.HasHeader(header)); 
+            }
+        }
+
+        [Test]
+        public void HasHeader_HeaderDoesNotExistWithNullRemovalStreamReader()
+        {
+            string header = "Phone Number";
+
+            using (CsvReader csvReader = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                Assert.IsFalse(csvReader.HasHeader(header));
+            }
+        }
+
+        [Test]
+        public void HasHeader_NullFieldHeadersWithNullRemovalStreamReader()
+        {
+            string header = "NonExistingHeader";
+
+            using (CsvReader csvReader = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("Value1,Value2")), false, Encoding.ASCII))
+            {
+                Assert.IsFalse(csvReader.HasHeader(header));
+            }
+        }
+
+        #endregion
+
+        #region CopyCurrentRecordTo
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void CopyCurrentRecordToTest1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                csv.CopyCurrentRecordTo(new string[CsvReaderSampleData.SampleData1RecordCount]);
+            }
+        }
+
+        #endregion
+
+        #region MoveTo tests
+
+        [Test]
+        public void MoveToTest1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                for (int i = 0; i < CsvReaderSampleData.SampleData1RecordCount; i++)
+                {
+                    Assert.IsTrue(csv.MoveTo(i));
+                    CsvReaderSampleData.CheckSampleData1(i, csv);
+                }
+            }
+        }
+
+        [Test]
+        public void MoveToTest2WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.MoveTo(1));
+                Assert.IsFalse(csv.MoveTo(0));
+            }
+        }
+
+        [Test]
+        public void MoveToTest3WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                Assert.IsFalse(csv.MoveTo(CsvReaderSampleData.SampleData1RecordCount));
+            }
+        }
+
+        [Test]
+        public void MoveToTest4WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                csv.SupportsMultiline = false;
+
+                string[] headers = csv.GetFieldHeaders();
+
+                Assert.IsTrue(csv.MoveTo(2));
+                Assert.AreEqual(2, csv.CurrentRecordIndex);
+                CsvReaderSampleData.CheckSampleData1(csv, false);
+            }
+        }
+
+        [Test]
+        public void MoveToTest5WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), false, Encoding.ASCII))
+            {
+                Assert.IsTrue(csv.MoveTo(-1));
+                csv.MoveTo(0);
+                Assert.IsFalse(csv.MoveTo(-1));
+            }
+        }
+
+        #endregion
+
+        #region Iteration tests
+
+        [Test]
+        public void IterationTest1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                int index = 0;
+
+                foreach (string[] record in csv)
+                {
+                    CsvReaderSampleData.CheckSampleData1(csv.HasHeaders, index, record);
+                    index++;
+                }
+            }
+        }
+
+        [Test]
+        public void IterationTest2WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                string[] previous = null;
+
+                foreach (string[] record in csv)
+                {
+                    Assert.IsFalse(ReferenceEquals(previous, record));
+
+                    previous = record;
+                }
+            }
+        }
+
+        #endregion
+
+        #region Indexer tests
+
+        [Test]
+        public void IndexerTest1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                for (int i = 0; i < CsvReaderSampleData.SampleData1RecordCount; i++)
+                {
+                    string s = csv[i, 0];
+                    CsvReaderSampleData.CheckSampleData1(i, csv);
+                }
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void IndexerTest2WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                string s = csv[1, 0];
+                s = csv[0, 0];
+            }
+        }
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void IndexerTest3WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(CsvReaderSampleData.SampleData1)), true, Encoding.ASCII))
+            {
+                string s = csv[CsvReaderSampleData.SampleData1RecordCount, 0];
+            }
+        }
+
+        #endregion
+
+        #region SkipEmptyLines
+
+        [Test]
+        public void SkipEmptyLinesTest1WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("00\n\n10")), false, Encoding.ASCII))
+            {
+                csv.SkipEmptyLines = false;
+
+                Assert.AreEqual(1, csv.FieldCount);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("00", csv[0]);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual(string.Empty, csv[0]);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("10", csv[0]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        [Test]
+        public void SkipEmptyLinesTest2WithNullRemovalStreamReader()
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes("00\n\n10")), false, Encoding.ASCII))
+            {
+                csv.SkipEmptyLines = true;
+
+                Assert.AreEqual(1, csv.FieldCount);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("00", csv[0]);
+
+                Assert.IsTrue(csv.ReadNextRecord());
+                Assert.AreEqual("10", csv[0]);
+
+                Assert.IsFalse(csv.ReadNextRecord());
+            }
+        }
+
+        #endregion
+
+        #region Trimming tests
+
+        [TestCase("", ValueTrimmingOptions.None, new string[] { })]
+        [TestCase("", ValueTrimmingOptions.QuotedOnly, new string[] { })]
+        [TestCase("", ValueTrimmingOptions.UnquotedOnly, new string[] { })]
+        [TestCase(" aaa , bbb , ccc ", ValueTrimmingOptions.None, new[] { " aaa ", " bbb ", " ccc " })]
+        [TestCase(" aaa , bbb , ccc ", ValueTrimmingOptions.QuotedOnly, new[] { " aaa ", " bbb ", " ccc " })]
+        [TestCase(" aaa , bbb , ccc ", ValueTrimmingOptions.UnquotedOnly, new[] { "aaa", "bbb", "ccc" })]
+        [TestCase("\" aaa \",\" bbb \",\" ccc \"", ValueTrimmingOptions.None, new[] { " aaa ", " bbb ", " ccc " })]
+        [TestCase("\" aaa \",\" bbb \",\" ccc \"", ValueTrimmingOptions.QuotedOnly, new[] { "aaa", "bbb", "ccc" })]
+        [TestCase("\" aaa \",\" bbb \",\" ccc \"", ValueTrimmingOptions.UnquotedOnly, new[] { " aaa ", " bbb ", " ccc " })]
+        [TestCase(" aaa , bbb ,\" ccc \"", ValueTrimmingOptions.None, new[] { " aaa ", " bbb ", " ccc " })]
+        [TestCase(" aaa , bbb ,\" ccc \"", ValueTrimmingOptions.QuotedOnly, new[] { " aaa ", " bbb ", "ccc" })]
+        [TestCase(" aaa , bbb ,\" ccc \"", ValueTrimmingOptions.UnquotedOnly, new[] { "aaa", "bbb", " ccc " })]
+        public void TrimFieldValuesTestWithNullRemovalStreamReader(string data, ValueTrimmingOptions trimmingOptions, params string[] expected)
+        {
+            using (CsvReader csv = new CsvReader(new MemoryStream(Encoding.ASCII.GetBytes(data)), false, Encoding.ASCII, CsvReader.DefaultDelimiter, CsvReader.DefaultQuote, CsvReader.DefaultEscape, CsvReader.DefaultComment, trimmingOptions))
+            {
+                while (csv.ReadNextRecord())
+                {
+                    string[] actual = new string[csv.FieldCount];
+                    csv.CopyCurrentRecordTo(actual);
+
+                    CollectionAssert.AreEqual(expected, actual);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/code/LumenWorks.Framework.Tests.Unit/IO/NullRemovalStreamTest.cs
+++ b/code/LumenWorks.Framework.Tests.Unit/IO/NullRemovalStreamTest.cs
@@ -1,0 +1,207 @@
+﻿namespace LumenWorks.Framework.Tests.Unit.IO
+{
+    using System;
+    using System.IO;
+    using System.Text;
+
+    using Framework.IO;
+
+    using NUnit.Framework;
+
+    public class NullRemovalStreamTest
+    {
+        [Test]
+        [TestCase(true, "[removed {0} null bytes]", 50000)]
+        [TestCase(false, "", 50000)]
+        public void TestInputContainsOnlyNull(bool addMark, string template, int size)
+        {
+            byte[] input = new byte[size];
+            byte[] buffer = new byte[4096];
+            string expected = string.Format(template, size);
+
+            StringBuilder result = new StringBuilder();
+            int total = ReadFromNullRemovalStream(input, buffer, result, addMark);
+            Assert.AreEqual(expected.Length, total);
+            Assert.AreEqual(expected, result.ToString());
+        }
+
+        [Test]
+        [TestCase(true, "[removed {0} null bytes]", 20000, 100)]
+        [TestCase(false, "", 20000, 100)]
+        public void TestInputWithNullPrefix(bool addMark, string template, int size, int numberOfNull)
+        {
+            byte[] input = new byte[size];
+            byte[] buffer = new byte[4096];
+            string expected = string.Format(template, numberOfNull) + new string('a', size - numberOfNull);
+
+            for (int i = 0; i < size; i++)
+            {
+                if (i >= numberOfNull)
+                {
+                    input[i] = Convert.ToByte('a');
+                }
+                else
+                {
+                    input[i] = 0;
+                }
+            }
+
+            StringBuilder result = new StringBuilder();
+            int total = ReadFromNullRemovalStream(input, buffer, result, addMark);
+            Assert.AreEqual(expected.Length, total);
+            Assert.AreEqual(expected, result.ToString());
+        }
+
+        [Test]
+        [TestCase(true, "[removed {0} null bytes]", 10000, 400)]
+        [TestCase(false, "", 10000, 400)]
+        public void TestInputWithNullSuffix(bool addMark, string template, int size, int numberOfNonNull)
+        {
+            byte[] input = new byte[size];
+            byte[] buffer = new byte[4096];
+            string expected = new string('a', numberOfNonNull) + string.Format(template, size - numberOfNonNull);
+
+            for (int i = 0; i < size; i++)
+            {
+                if (i < numberOfNonNull)
+                {
+                    input[i] = Convert.ToByte('a');
+                }
+                else
+                {
+                    input[i] = 0;
+                }
+            }
+
+            StringBuilder result = new StringBuilder();
+            int total = ReadFromNullRemovalStream(input, buffer, result, addMark);
+            Assert.AreEqual(expected.Length, total);
+            Assert.AreEqual(expected, result.ToString());
+        }
+
+        [Test]
+        [TestCase(true, "[removed {0} null bytes]", 30000, 300)]
+        [TestCase(false, "", 30000, 300)]
+        public void TestInputWithNullInTheMiddle(bool addMark, string template, int size, int numberOfNull)
+        {
+            byte[] input = new byte[size];
+            byte[] buffer = new byte[4096];
+            string expected = new string('a', numberOfNull) + string.Format(template, numberOfNull) + new string('a', size - numberOfNull * 2);
+
+            for (int i = 0; i < size; i++)
+            {
+                if (i < numberOfNull || i >= numberOfNull + numberOfNull)
+                {
+                    input[i] = Convert.ToByte('a');
+                }
+                else
+                {
+                    input[i] = 0;
+                }
+            }
+
+            StringBuilder result = new StringBuilder();
+            int total = ReadFromNullRemovalStream(input, buffer, result, addMark);
+            Assert.AreEqual(expected.Length, total);
+            Assert.AreEqual(expected, result.ToString());
+        }
+
+        [Test]
+        [TestCase(true, "[removed {0} null bytes]", 40000, 10000)]
+        [TestCase(false, "", 40000, 10000)]
+        public void TestInputWithNullAtBothEnds(bool addMark, string template, int size, int numberOfNull)
+        {
+            byte[] input = new byte[size];
+            byte[] buffer = new byte[4096];
+            string expected = string.Format(template, numberOfNull) + new string('a', numberOfNull * 2) + string.Format(template, numberOfNull);
+
+            for (int i = 0; i < size; i++)
+            {
+                if (i < numberOfNull || i >= numberOfNull * 3)
+                {
+                    input[i] = 0;
+                }
+                else
+                {
+                    input[i] = Convert.ToByte('a');
+                }
+            }
+
+            StringBuilder result = new StringBuilder();
+            int total = ReadFromNullRemovalStream(input, buffer, result, addMark);
+            Assert.AreEqual(expected.Length, total);
+            Assert.AreEqual(expected, result.ToString());
+        }
+
+        [Test]
+        [TestCase(true, 200, 59)]
+        [TestCase(false, 200, 59)]
+        public void TestInputWithFewerThanThresholdNullBytes(bool addMark, int size, int numberOfNull)
+        {
+            byte[] input = new byte[size];
+            byte[] buffer = new byte[4096];
+            string expected = new string(new char[numberOfNull]) + new string('a', size - numberOfNull);
+
+            for (int i = 0; i < size; i++)
+            {
+                if (i >= numberOfNull)
+                {
+                    input[i] = Convert.ToByte('a');
+                }
+                else
+                {
+                    input[i] = 0;
+                }
+            }
+
+            StringBuilder result = new StringBuilder();
+            int total = ReadFromNullRemovalStream(input, buffer, result, addMark);
+            Assert.AreEqual(expected.Length, total);
+            Assert.AreEqual(expected, result.ToString());
+        }
+
+        [Test]
+        [TestCase(true, 200, 60, "[removed {0} null bytes]")]
+        [TestCase(false, 200, 60, "")]
+        public void TestInputWithExactThresholdNullBytes(bool addMark, int size, int numberOfNull, string template)
+        {
+            byte[] input = new byte[size];
+            byte[] buffer = new byte[4096];
+            string expected = (addMark ? string.Format(template, numberOfNull) : "") + new string('a', size - numberOfNull);
+
+            for (int i = 0; i < size; i++)
+            {
+                if (i >= numberOfNull)
+                {
+                    input[i] = Convert.ToByte('a');
+                }
+                else
+                {
+                    input[i] = 0;
+                }
+            }
+
+            StringBuilder result = new StringBuilder();
+            int total = ReadFromNullRemovalStream(input, buffer, result, addMark);
+            Assert.AreEqual(expected.Length, total);
+            Assert.AreEqual(expected, result.ToString());
+        }
+
+        private int ReadFromNullRemovalStream(byte[] input, byte[] buffer, StringBuilder sb, bool addMark)
+        {
+            using (MemoryStream memoryStream = new MemoryStream(input))
+            using (NullRemovalStream nullRemovalStream = new NullRemovalStream(memoryStream, addMark))
+            {
+                int readCount = nullRemovalStream.Read(buffer, 0, 4096);
+                int total = readCount;
+                while (readCount != 0)
+                {
+                    sb.Append(Encoding.ASCII.GetString(buffer, 0, readCount));
+                    readCount = nullRemovalStream.Read(buffer, 0, 4096);
+                    total += readCount;
+                }
+                return total;
+            }
+        }
+    }
+}

--- a/code/LumenWorks.Framework.Tests.Unit/LumenWorks.Framework.Tests.Unit.csproj
+++ b/code/LumenWorks.Framework.Tests.Unit/LumenWorks.Framework.Tests.Unit.csproj
@@ -78,7 +78,9 @@
     <Compile Include="IO\Csv\CsvReaderIDataReaderTest.cs" />
     <Compile Include="IO\Csv\CsvReaderMalformedTest.cs" />
     <Compile Include="IO\Csv\CsvReaderSampleData.cs" />
+    <Compile Include="IO\Csv\CsvReaderWithNullRemovalTest.cs" />
     <Compile Include="IO\Csv\CsvReaderTest.cs" />
+    <Compile Include="IO\NullRemovalStreamTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I discovered this when processing a 1GB file which contains 700MB of null bytes.
The regular CSVReader took 5 hours to complete and memory usage was around 2GB during the runtime.