### PR TITLE
Use StringBuilder instead of string concatenation to improve huge cell processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and provides fast parsing and reading of CSV files
 [![NuGet](https://img.shields.io/nuget/v/LumenWorksCsvReader.svg)](https://www.nuget.org/packages/LumenWorksCsvReader/)
 [![Build status](https://ci.appveyor.com/api/projects/status/ouvglmaox83bpyti/branch/master?svg=true)](https://ci.appveyor.com/project/PaulHatcher/csvreader/branch/master)
 
-To this end it is a straight drop-in replacement for the existing NuGet package [LumenWork.Framework.IO](https://www.nuget.org/packages/LumenWorks.Framework.IO/), but with additional
+To this end it is a straight drop-in replacement for the existing NuGet package [LumenWorks.Framework.IO](https://www.nuget.org/packages/LumenWorks.Framework.IO/), but with additional
 capabilities; the other rationale for the project is that the code is not available elsewhere in a public source repository, making it difficult to extend/contribute to.
 
 Welcome to contributions from anyone.

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ A good starting point is to look at Sébastien's [article](http://www.codeprojec
 
 A basic use of the reader something like this...
 ```csharp
-    using System.IO;
-    using LumenWorks.Framework.IO.Csv;
+using System.IO;
+using LumenWorks.Framework.IO.Csv;
 
-    void ReadCsv()
+void ReadCsv()
+{
+    // open the file "data.csv" which is a CSV file with headers
+    using (var csv = new CachedCsvReader(new StreamReader("data.csv"), true))
     {
-        // open the file "data.csv" which is a CSV file with headers
-        using (var csv = new CachedCsvReader(new StreamReader("data.csv"), true))
-        {
-            // Field headers will automatically be used as column names
-            myDataGrid.DataSource = csv;
-        }
+        // Field headers will automatically be used as column names
+        myDataGrid.DataSource = csv;
     }
+}
 ```
 Having said that, there are some extensions built into this version of the library that it is worth mentioning.
 
@@ -97,40 +97,40 @@ One use of CSV Reader is to have a nice .NET way of using SQL Bulk Copy (SBC) ra
 A couple of issues arise when using SBC
     1. SBC wants the data presented as the correct type rather than as string
     2. You need to map between the table destination columns and the CSV if the order does not match *exactly*
-    
+
 Below is a example using the Columns collection to set up the correct metadata for SBC
 ```csharp
-    public void Import(string fileName, string connectionString)
+public void Import(string fileName, string connectionString)
+{
+    using (var reader = new CsvReader(new StreamReader(fileName), false))
     {
-        using (var reader = new CsvReader(new StreamReader(fileName), false))
+        reader.Columns = new List<LumenWorks.Framework.IO.Csv.Column>
         {
-            reader.Columns = new List<LumenWorks.Framework.IO.Csv.Column>
-            {
-                new LumenWorks.Framework.IO.Csv.Column { Name = "PriceDate", Type = typeof(DateTime) },
-                new LumenWorks.Framework.IO.Csv.Column { Name = "OpenPrice", Type = typeof(decimal) },
-                new LumenWorks.Framework.IO.Csv.Column { Name = "HighPrice", Type = typeof(decimal) },
-                new LumenWorks.Framework.IO.Csv.Column { Name = "LowPrice", Type = typeof(decimal) },
-                new LumenWorks.Framework.IO.Csv.Column { Name = "ClosePrice", Type = typeof(decimal) },
-                new LumenWorks.Framework.IO.Csv.Column { Name = "Volume", Type = typeof(int) },
-            };
+            new LumenWorks.Framework.IO.Csv.Column { Name = "PriceDate", Type = typeof(DateTime) },
+            new LumenWorks.Framework.IO.Csv.Column { Name = "OpenPrice", Type = typeof(decimal) },
+            new LumenWorks.Framework.IO.Csv.Column { Name = "HighPrice", Type = typeof(decimal) },
+            new LumenWorks.Framework.IO.Csv.Column { Name = "LowPrice", Type = typeof(decimal) },
+            new LumenWorks.Framework.IO.Csv.Column { Name = "ClosePrice", Type = typeof(decimal) },
+            new LumenWorks.Framework.IO.Csv.Column { Name = "Volume", Type = typeof(int) },
+        };
 
-            // Now use SQL Bulk Copy to move the data
-            using (var sbc = new SqlBulkCopy(connectionString))
-            {
-                sbc.DestinationTableName = "dbo.DailyPrice";
-                sbc.BatchSize = 1000;
+        // Now use SQL Bulk Copy to move the data
+        using (var sbc = new SqlBulkCopy(connectionString))
+        {
+            sbc.DestinationTableName = "dbo.DailyPrice";
+            sbc.BatchSize = 1000;
 
-                sbc.AddColumnMapping("PriceDate", "PriceDate");
-                sbc.AddColumnMapping("OpenPrice", "OpenPrice");
-                sbc.AddColumnMapping("HighPrice", "HighPrice");
-                sbc.AddColumnMapping("LowPrice", "LowPrice");
-                sbc.AddColumnMapping("ClosePrice", "ClosePrice");
-                sbc.AddColumnMapping("Volume", "Volume");
+            sbc.AddColumnMapping("PriceDate", "PriceDate");
+            sbc.AddColumnMapping("OpenPrice", "OpenPrice");
+            sbc.AddColumnMapping("HighPrice", "HighPrice");
+            sbc.AddColumnMapping("LowPrice", "LowPrice");
+            sbc.AddColumnMapping("ClosePrice", "ClosePrice");
+            sbc.AddColumnMapping("Volume", "Volume");
 
-                sbc.WriteToServer(reader);
-            }
+            sbc.WriteToServer(reader);
         }
     }
+}
 ```
 The method AddColumnMapping is an extension I wrote to simplify adding mappings to SBC
 ```csharp
@@ -152,64 +152,64 @@ public static class SqlBulkCopyExtensions
         return map;
     }
 }
-```    
+```
 
 One other issue recently arose where we wanted to use SBC but some of the data was not in the file itself, but metadata that needed to be included on every row. The solution was to amend the CSV reader and Columns collection to allow default values to be provided that are not in the data.
 
 The additional columns should be added at the end of the Columns collection to avoid interfering with the parsing, see the amended example below...
 ```csharp
-    public void Import(string fileName, string connectionString)
+public void Import(string fileName, string connectionString)
+{
+    using (var reader = new CsvReader(new StreamReader(fileName), false))
     {
-        using (var reader = new CsvReader(new StreamReader(fileName), false))
+        reader.Columns = new List<LumenWorks.Framework.IO.Csv.Column>
         {
-            reader.Columns = new List<LumenWorks.Framework.IO.Csv.Column>
-            {
-                ...
-                new LumenWorks.Framework.IO.Csv.Column { Name = "Volume", Type = typeof(int) },
-                // NB Fake column so bulk import works
-                new LumenWorks.Framework.IO.Csv.Column { Name = "Ticker", Type = typeof(string) },
-            };
+            ...
+            new LumenWorks.Framework.IO.Csv.Column { Name = "Volume", Type = typeof(int) },
+            // NB Fake column so bulk import works
+            new LumenWorks.Framework.IO.Csv.Column { Name = "Ticker", Type = typeof(string) },
+        };
 
-            // Fix up the column defaults with the values we need
-            reader.UseColumnDefaults = true;
-            reader.Columns[reader.GetFieldIndex("Ticker")] = Path.GetFileNameWithoutExtension(fileName);
+        // Fix up the column defaults with the values we need
+        reader.UseColumnDefaults = true;
+        reader.Columns[reader.GetFieldIndex("Ticker")] = Path.GetFileNameWithoutExtension(fileName);
 
-            // Now use SQL Bulk Copy to move the data
-            using (var sbc = new SqlBulkCopy(connectionString))
-            {
-                ...
-                sbc.AddColumnMapping("Ticker", "Ticker");
+        // Now use SQL Bulk Copy to move the data
+        using (var sbc = new SqlBulkCopy(connectionString))
+        {
+            ...
+            sbc.AddColumnMapping("Ticker", "Ticker");
 
-                sbc.WriteToServer(reader);
-            }
+            sbc.WriteToServer(reader);
         }
     }
+}
 ```
 To give an idea of performance, this took a naive sample app using an ORM from 2m 27s to 1.37s using SBC and the full import took just over 11m to import 9.8m records.
 
-### Null Bytes Removal StreamReader
+### Null Byte Removal StreamReader
 Use NullRemovalStreamReader when CSV files contain large number of null bytes and you do not control how to generate CSV files.
 
-If you ever experienced "System.OutOfMemoryException" or long processing time, you will most likely to get a huge performance gain with NullRemovalStreamReader.
+If you ever experienced "System.OutOfMemoryException" or long processing time, you will most likely get a huge performance gain with NullRemovalStreamReader.
 ```csharp
-    public void Process(string path, bool addMark)
+public void Process(string path, bool addMark)
+{
+    using (StreamReader stream = new StreamReader(path))
+    using (CsvReader csv = new CsvReader(stream.BaseStream, false, stream.CurrentEncoding, addMark))
+    // or using (CsvReader csv = new CsvReader(File.OpenRead(path), false, Encoding.UTF8, addMark))
     {
-        using (StreamReader stream = new StreamReader(path))
-        using (CsvReader csv = new CsvReader(stream.BaseStream, false, stream.CurrentEncoding, addMark))
-        // or using (CsvReader csv = new CsvReader(File.OpenRead(path), false, Encoding.UTF8, addMark))
+        while (csv.ReadNextRecord())
         {
-            while (csv.ReadNextRecord())
-            {
-                string data = csv[i];
-                // do stuff with the data
-            }
+            string data = csv[i];
+            // do stuff
         }
     }
+}
 ```
 
-When addMark is true, consecutive null bytes will be replaced by [removed x null bytes] to indicate the removal, you can see this from benchmark output below.
+When addMark is true, consecutive null bytes will be replaced by [removed x null bytes] to indicate the removal, you can see this from the benchmark output below.
 
-Performance difference when tested with 20 million null bytes (20MB in storage) :
+Performance differences shown when tested with 20 million null bytes (20MB in storage) :
 ```csharp
 CsvReader -     without using NullRemovalStreamReader : 156248815 ticks, 57.2749 sec., 0.3492 MB/sec.
 
@@ -220,9 +220,9 @@ CsvReader - with NullRemovalStreamReader with    mark : 447222 ticks, 0.1639 sec
 AddMark =(True) LastCell =(cell63 followed by 20971520 null bytes[removed 20971520 null bytes])
 ```
 
-Adjust number of null bytes and run benchmark to see how much memory/time you will be able to save:
+Adjust number of null bytes in benchmark to see how much memory/time you will be able to save:
 ```csharp
-X:\Path\CsvReader\code\CsvReaderBenchmarks\bin\Debug>CsvReaderBenchmarks.exe CsvNullRemovalStreamReader
+X:\Path\CsvReader\build\Debug\CsvReaderBenchmarks\net461>CsvReaderBenchmarks.exe CsvNullRemovalStreamReader
 ```
 
 

--- a/code/LumenWorks.Framework.IO/Csv/Stream/NullRemovalStream.cs
+++ b/code/LumenWorks.Framework.IO/Csv/Stream/NullRemovalStream.cs
@@ -11,6 +11,9 @@ namespace LumenWorks.Framework.IO
         private byte[] _buffer;
         private int _bufferIndex;
         private int _bufferSize;
+        private byte[] _storage;
+        private int _storageIndex;
+        private int _storageSize;
         private Stream _source;
         private int _threshold;
 
@@ -36,6 +39,10 @@ namespace LumenWorks.Framework.IO
             _buffer = new byte [bufferSize];
             _threshold = threshold < 60 ? 60 : threshold;
             PopulateBuffer();
+
+            _storage = new byte[4096];
+            _storageIndex = 0;
+            _storageSize = 0;
         }
 
         public override bool CanRead => _source.CanRead;
@@ -53,31 +60,16 @@ namespace LumenWorks.Framework.IO
         }
 
 #if !NETSTANDARD1_3
-        public override void Close()
-        {
-            _source.Close();
-        }
+        public override void Close() => _source.Close();
 #endif
 
-        public override void Flush()
-        {
-            _source.Flush();
-        }
+        public override void Flush() => _source.Flush();
 
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            return _source.Seek(offset, origin);
-        }
+        public override long Seek(long offset, SeekOrigin origin) => _source.Seek(offset, origin);
 
-        public override void SetLength(long value)
-        {
-            _source.SetLength(value);
-        }
+        public override void SetLength(long value) => _source.SetLength(value);
 
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            _source.Write(buffer, offset, count);
-        }
+        public override void Write(byte[] buffer, int offset, int count) => _source.Write(buffer, offset, count);
 
         public override int Read(byte[] target, int offset, int count)
         {
@@ -86,40 +78,59 @@ namespace LumenWorks.Framework.IO
                 return 0;
             }
 
-            int targetIndex = offset;
-            int dataRead = 0;
-            int nullCount = 0;
+            var targetIndex = offset;
+            var dataRead = 0;
+            var nullCount = 0;
 
             if (_bufferSize == 0)
             {
                 return 0;
             }
 
-            byte lastByteInBuffer = 1;
+            var lastByteInBuffer = 1;
             while (dataRead < count)
             {
-                // if last PopulateBuffer() exhausted the source stream, _bufferSize will be less than 4096
                 lastByteInBuffer = 1;
-                if (_bufferIndex == _bufferSize)
+                var current = 0;
+                var readFromStorage = false;
+                if (_storageSize > 0)
                 {
-                    // save the current last byte in _buffer before populating _buffer again
-                    lastByteInBuffer = _bufferIndex > 0 ? _buffer[_bufferIndex - 1] : lastByteInBuffer;
-                    PopulateBuffer();
-                    if (_bufferSize == 0)
+                    // read from temporary storage first
+                    current = _storage[_storageIndex++];
+                    _storageSize--;
+                    readFromStorage = true;
+                }
+                else
+                {
+                    // if last PopulateBuffer() exhausted the source stream, _bufferSize will be less than 4096
+                    if (_bufferIndex == _bufferSize)
                     {
-                        break;
+                        // save the current last byte in _buffer before populating _buffer again
+                        lastByteInBuffer = _bufferIndex > 0 ? _buffer[_bufferIndex - 1] : lastByteInBuffer;
+                        PopulateBuffer();
+                        if (_bufferSize == 0)
+                        {
+                            break;
+                        }
                     }
+                    current = _buffer[_bufferIndex];
                 }
 
-                byte current = _buffer[_bufferIndex];
-                if (current == 0)
+                if (current == 0 && !readFromStorage)
                 {
                     nullCount++;
                 }
                 else
                 {
-                    bool lastIsNull = _bufferIndex > 0 ? _buffer[_bufferIndex - 1] == 0 : lastByteInBuffer == 0;
-                    int newTargetIndex = targetIndex;
+                    var processed = false;
+                    if (_storageSize == 0 && _storageIndex > 0 && !readFromStorage)
+                    {
+                        // last iteration was reading from storage so no need to process again even the last byte was null; best place to reset storage index
+                        _storageIndex = 0;
+                        processed = true;
+                    }
+                    var lastIsNull = !readFromStorage && !processed && (_bufferIndex > 0 ? _buffer[_bufferIndex - 1] == 0 : lastByteInBuffer == 0);
+                    var newTargetIndex = targetIndex;
                     if (lastIsNull)
                     {
                         // first non null byte
@@ -134,7 +145,10 @@ namespace LumenWorks.Framework.IO
                     dataRead += newTargetIndex - targetIndex + 1;
                     targetIndex = newTargetIndex + 1;
                 }
-                _bufferIndex++;
+                if (!readFromStorage)
+                {
+                    _bufferIndex++;
+                }
             }
             if (nullCount > 0 && dataRead == 0 || _bufferSize == 0 && lastByteInBuffer == 0)
             {
@@ -146,15 +160,17 @@ namespace LumenWorks.Framework.IO
 
         private int Process(byte[] target, int targetIndex, int nullCount)
         {
-            var template = "[removed {0} null bytes]";
-            var mark = string.Format(template, nullCount);
-
-            if (nullCount < _threshold || (_addMark && targetIndex + mark.Length > target.Length))
+            if (nullCount < _threshold)
             {
                 while (nullCount > 0 && targetIndex < target.Length)
                 {
                     target[targetIndex] = 0;
                     targetIndex++;
+                    nullCount--;
+                }
+                while (nullCount > 0)
+                {
+                    _storage[_storageSize++] = 0;
                     nullCount--;
                 }
                 return targetIndex;
@@ -165,11 +181,19 @@ namespace LumenWorks.Framework.IO
                 return targetIndex;
             }
 
-            // nullCount >= _threshold
+            var template = "[removed {0} null bytes]";
+            var mark = string.Format(template, nullCount);
             foreach (var c in mark)
             {
-                target[targetIndex] = Convert.ToByte(c);
-                targetIndex++;
+                if (targetIndex < target.Length)
+                {
+                    target[targetIndex] = Convert.ToByte(c);
+                    targetIndex++;
+                }
+                else
+                {
+                    _storage[_storageSize++] = Convert.ToByte(c);
+                }
             }
             return targetIndex;
         }

--- a/code/LumenWorks.Framework.IO/Csv/Stream/NullRemovalStream.cs
+++ b/code/LumenWorks.Framework.IO/Csv/Stream/NullRemovalStream.cs
@@ -91,7 +91,7 @@ namespace LumenWorks.Framework.IO
             while (dataRead < count)
             {
                 lastByteInBuffer = 1;
-                var current = 0;
+                byte current = 0;
                 var readFromStorage = false;
                 if (_storageSize > 0)
                 {

--- a/code/LumenWorks.Framework.Tests.Unit/IO/NullRemovalStreamTest.cs
+++ b/code/LumenWorks.Framework.Tests.Unit/IO/NullRemovalStreamTest.cs
@@ -8,6 +8,8 @@ using NUnit.Framework;
 
 namespace LumenWorks.Framework.Tests.Unit.IO
 {
+    using System.Linq;
+
     public class NullRemovalStreamTest
     {
         [Test]
@@ -185,6 +187,123 @@ namespace LumenWorks.Framework.Tests.Unit.IO
             var total = ReadFromNullRemovalStream(input, buffer, result, addMark);
             Assert.AreEqual(expected.Length, total);
             Assert.AreEqual(expected, result.ToString());
+        }
+
+
+        [Test]
+        [TestCase(true, 8192, 60)]
+        [TestCase(false, 8192, 60)]
+        public void TestInputWithNullBytesAboveThresholdFromLastInBuffer(bool addMark, int size, int numberOfNull)
+        {
+            var input = new byte[size];
+            var buffer = new byte[4096];
+            var expected = string.Empty;
+            if (addMark)
+            {
+                expected = new string('a', 4095) + new string(new char[1]) + new string('a', 8192 - 4095 - numberOfNull);
+            }
+            else
+            {
+                expected = new string('a', 4095) + new string('a', 8192 - 4095 - numberOfNull);
+            }
+
+            for (var i = 0; i < size; i++)
+            {
+                if (i >= 4095 && i < 4095 + numberOfNull)
+                {
+                    input[i] = 0;
+                }
+                else
+                {
+                    input[i] = Convert.ToByte('a');
+                }
+            }
+
+            var result = new StringBuilder();
+            var total = ReadFromNullRemovalStream(input, buffer, result, addMark);
+            Assert.AreEqual(expected.Length, total);
+            Assert.AreEqual(expected, result.ToString());
+        }
+
+        [Test]
+        [Repeat(5)]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestInputWithRandomNullBytes(bool addMark)
+        {
+            var rand = new Random();
+            var size = 4096 * 4096;
+            var inputIndex = 0;
+            var input = new byte[size];
+            var expectedIndex = 0;
+            var expected = new byte[size];
+            var numberOfNull = 0;
+            var numberOfChar = 0;
+            var totalNull = 0;
+            var totalRead = 0;
+            var result = new StringBuilder();
+            var markTemplate = "[removed {0} null bytes]";
+
+            while (inputIndex < size)
+            {
+                // generate number of nulls (1 <= x <= 70) close to the threshold to maximize the chance of having null bytes cross buffer populate
+                numberOfNull = rand.Next(1, Math.Min(70, size - inputIndex));
+                for (int i = inputIndex; i < inputIndex + numberOfNull; i++)
+                {
+                    input[i] = 0;
+                    if (numberOfNull < 60)
+                    {
+                        expected[expectedIndex++] = 0;
+                    }
+                }
+                if(numberOfNull >= 60 && addMark)
+                {
+                    foreach (char c in string.Format(markTemplate, numberOfNull))
+                    {
+                        expected[expectedIndex++] = (byte)c;
+                    }
+                }
+
+                inputIndex += numberOfNull;
+                totalNull += numberOfNull;
+                if (inputIndex < size)
+                {
+                    numberOfChar = rand.Next(1, Math.Min(10, size - inputIndex));
+                    for (int i = inputIndex; i < inputIndex + numberOfChar; i++)
+                    {
+                        input[i] = (byte)'a';
+                        expected[expectedIndex++] = (byte)'a';
+                    }
+                    inputIndex += numberOfChar;
+                }
+            }
+
+            using (var memoryStream = new MemoryStream(input))
+            using (var nullRemovalStream = new NullRemovalStream(memoryStream, addMark))
+            {
+                var buffer = new byte[4096];
+
+                var readCount = nullRemovalStream.Read(buffer, 0, 4096);
+                while (readCount > 0)
+                {
+                    totalRead += readCount;
+                    result.Append(Encoding.ASCII.GetString(buffer, 0, readCount));
+                    readCount = nullRemovalStream.Read(buffer, 0, 4096);
+                }
+            }
+
+            //File.WriteAllBytes($@"{Path.GetTempPath()}/1-input-{addMark}.txt",input);
+            //File.WriteAllBytes($@"{Path.GetTempPath()}/2-expected-{addMark}.txt",expected);
+            //File.WriteAllText( $@"{Path.GetTempPath()}/3-result-{addMark}.txt",result.ToString());
+
+            Assert.True(totalRead < size);
+            Assert.True(totalRead <= expectedIndex);
+            var totalNumberOfA = input.Count(c => c == 'a');
+            Assert.AreEqual(size - totalNull, totalNumberOfA, "(number of a) and (size - number of null) should be equal!");
+            var expectedCountA = expected.Count(c => c == 'a');
+            Assert.AreEqual(totalNumberOfA, expectedCountA, "Expected buffer should contain same number of a!");
+            var processedCount = result.ToString().Count(c => c == 'a');
+            Assert.AreEqual(totalNumberOfA, processedCount, "Result sbuilder should contain same number of a!");
         }
 
         private int ReadFromNullRemovalStream(byte[] input, byte[] buffer, StringBuilder sb, bool addMark)


### PR DESCRIPTION
Checkout commit 69baca7, compile and run the newly added test to see the memory consumption and processing speed of string concatenation.

Checkout commit ee72a8c, compile and run the same test to observe the improvements.

Results from my local runs:
```
D:\Source\CsvReader\build\Debug\CsvReaderBenchmarks\net461>CsvReaderBenchmarks.exe CsvStringBuilder
CsvReader - performance test with large cell : 12021727 ticks, 4.4078 sec., 1.1344 MB/sec.

D:\Source\CsvReader\build\Debug\CsvReaderBenchmarks\net461>CsvReaderBenchmarks.exe CsvStringBuilder
CsvReader - performance test with large cell : 246038 ticks, 0.0902 sec., 55.4264 MB/sec.
```